### PR TITLE
Make ng build command compatible with ng cli 6

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,10 +13,11 @@ module.exports = {
     var DeployPlugin = DeployPluginBase.extend({
       name: options.name,
       defaultConfig: {
-        environment: 'prod',
+        environment: 'production',
         outputPath: 'dist',
         deployUrl: '',
-        baseHref: '/'
+        baseHref: '/',
+        oldNgCli: false
       },
 
       build: function(/* context */) {
@@ -25,11 +26,13 @@ module.exports = {
         var buildEnv   = this.readConfig('environment');
         var deployUrl  = this.readConfig('deployUrl');
         var baseHref   = this.readConfig('baseHref');
+        var oldNgCli   = this.readConfig('oldNgCli');
+        var environment = oldNgCli ? '--environment ' + buildEnv : '--configuration=' + buildEnv;
 
         this.log('building app to `' + outputPath + '` using buildEnv `' + buildEnv + '`...', { verbose: true });
 
         return new RSVP.Promise(function(resolve, reject) {
-          exec('ng build --environment ' + buildEnv + ' --output-path ' + outputPath + ' --output-hashing all'
+          exec('ng build ' + environment + ' --output-path ' + outputPath + ' --output-hashing all'
             + (deployUrl ? ' --deploy-url=' + deployUrl : '')
             + (baseHref ? ' --base-href=' + baseHref : ''),
             {maxBuffer: 1024 * 1024 * 32},

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = {
     var DeployPlugin = DeployPluginBase.extend({
       name: options.name,
       defaultConfig: {
-        environment: 'production',
+        environment: 'prod',
         outputPath: 'dist',
         deployUrl: '',
         baseHref: '/'

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const RSVP = require('rsvp');
 const glob  = require('glob');
 const DeployPluginBase = require('ember-cli-deploy-plugin');
 const exec = require('child_process').exec;
+const execSync = require ('child_process').execSync;
 
 module.exports = {
   name: 'deployjs-angular-build',
@@ -16,8 +17,7 @@ module.exports = {
         environment: 'production',
         outputPath: 'dist',
         deployUrl: '',
-        baseHref: '/',
-        oldNgCli: false
+        baseHref: '/'
       },
 
       build: function(/* context */) {
@@ -26,13 +26,21 @@ module.exports = {
         var buildEnv   = this.readConfig('environment');
         var deployUrl  = this.readConfig('deployUrl');
         var baseHref   = this.readConfig('baseHref');
-        var oldNgCli   = this.readConfig('oldNgCli');
-        var environment = oldNgCli ? '--environment ' + buildEnv : '--configuration=' + buildEnv;
+
+        var regex = /Angular CLI: ([0-9])\./;
+        var ngCliVersionBuffer = execSync('ng version').toString('utf-8') || '';
+        var substring = ngCliVersionBuffer.match(regex);
+        var ngCliVersion = substring[1] || 1;
+        var environmentOption = ngCliVersion >= 6 ? '--configuration=' : '--environment ';
+
+        if (ngCliVersion >= 6 && buildEnv === 'prod') {
+          buildEnv = 'production';
+        }
 
         this.log('building app to `' + outputPath + '` using buildEnv `' + buildEnv + '`...', { verbose: true });
 
         return new RSVP.Promise(function(resolve, reject) {
-          exec('ng build ' + environment + ' --output-path ' + outputPath + ' --output-hashing all'
+          exec('ng build ' + environmentOption + buildEnv + ' --output-path ' + outputPath + ' --output-hashing all'
             + (deployUrl ? ' --deploy-url=' + deployUrl : '')
             + (baseHref ? ' --base-href=' + baseHref : ''),
             {maxBuffer: 1024 * 1024 * 32},


### PR DESCRIPTION
As this does not work anymore with Angular CLI 6 I tried to fix it.

The ng build --environment option has to be replaced with --configuration=
I tried to make this optional compatible with older CLI versions by using the oldNgCli flag in the deploys-angular-build env settings

```
ENV['deployjs-angular-build'] = {
  environment: 'production',
  oldNgCli: false
}
```
