### PR TITLE
Fixed parsing angular 10+ cli version

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = {
         var baseHref   = this.readConfig('baseHref');
         var aot        = this.readConfig('aot');
 
-        var regex = /Angular CLI: ([0-9])\./;
+        var regex = /Angular CLI: ([0-9]+)\./;
         var ngCliVersionBuffer = execSync('ng version').toString('utf-8') || '';
         var substring = ngCliVersionBuffer.match(regex);
         var ngCliVersion = substring[1] || 1;


### PR DESCRIPTION
The regex used for parsing angular cli version expects a single digit number, so it breaks if angular 10 or newer is used